### PR TITLE
INSTALL:expand dependency information

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,8 +7,15 @@
 
      to compile each part of vfu manually do this:
 
+     -- `git clone yascreen https://github.com/bbonev/yascreen.git`
+     -- go to `yascreen` directory
+     -- run 'make'
+     -- cd ..
+     -- `git clone https://github.com/cade-vs/vslib.git`
      -- go to `vslib' directory
      -- run `make'
+     -- cd ..
+     -- `git clone https://github.com/cade-vs/vfu.git`
      -- go to `vfu' directory
      -- run `make'
 


### PR DESCRIPTION
I added this because I received this error when compiling vslib:

```
In file included from conmenu.cpp:12:0:
./unicon.h:22:26: fatal error: yascreen.h: No such file or directory
     #include <yascreen.h>
                          ^
compilation terminated.
makefile:242: recipe for target '.OBJ.libvscony.a/conmenu.o' failed
make: *** [.OBJ.libvscony.a/conmenu.o] Error 1
```